### PR TITLE
Add minimum date validation to date input fields in booking and searc…

### DIFF
--- a/src/main/webapp/booking.jsp
+++ b/src/main/webapp/booking.jsp
@@ -175,7 +175,7 @@
 									<div class="field2">
 										<label for="date">Date</label>
 										<input type="date" name="up_t_date" id="date" class="date"
-											value="${ticket_up_form.date}">
+											value="${ticket_up_form.date}" min="<%= java.time.LocalDate.now() %>">
 
 										<div class="arrow_div">
 											<img src="img/arrow_ticket.png" class="arrow_ticket">

--- a/src/main/webapp/search_result.jsp
+++ b/src/main/webapp/search_result.jsp
@@ -164,7 +164,7 @@
 
 								<div class="field2">
 									<label for="date">Date</label>
-									<input type="date" name="t_date" id="date" class="date">
+									<input type="date" name="t_date" id="date" class="date" min="<%= java.time.LocalDate.now() %>">
 
 									<div class="arrow_div">
 										<img src="img/arrow_ticket.png" class="arrow_ticket">


### PR DESCRIPTION
This pull request introduces a small but important enhancement to the date input fields in the `booking.jsp` and `search_result.jsp` files. The changes ensure that users cannot select a date earlier than the current date, improving the user experience and preventing invalid date selections.

Date validation updates:

* [`src/main/webapp/booking.jsp`](diffhunk://#diff-4e6fcd723cc237e09e7d81d86d14d32c7ab3e8a3541d70c9b549160e52e457ddL178-R178): Added a `min` attribute to the date input field, setting the minimum selectable date to the current date using `<%= java.time.LocalDate.now() %>`.
* [`src/main/webapp/search_result.jsp`](diffhunk://#diff-d0031c3556e817e70b50e1f9ea419695ddd98b1854fd1302cd197a6793dd96f7L167-R167): Similarly, added a `min` attribute to the date input field for the search results page, ensuring the same restriction on date selection.…h result pages